### PR TITLE
docs link in top bar, mobile menu and footer

### DIFF
--- a/components/Button5/Button5.tsx
+++ b/components/Button5/Button5.tsx
@@ -14,6 +14,7 @@ type Props = {
     highlight?: boolean,
     contentId: string
     dataAnalytics: string
+    target?: '_blank' | undefined
 }
 
 type ButtonWrapperProps = {
@@ -25,6 +26,8 @@ type ButtonWrapperProps = {
    disabled?: boolean 
    text: string
    dataAnalytics: string
+   target?: '_blank' | undefined
+
 }
 
 
@@ -46,10 +49,11 @@ export function ButtonContent({...all}: ButtonContentProps) {
     )
 }
 
-export function ButtonWrapper({children, type, onClick, replace, link, disabled, text, dataAnalytics}: ButtonWrapperProps) {
+export function ButtonWrapper({children, type, onClick, replace, link, disabled, text, dataAnalytics, target}: ButtonWrapperProps) {
     return type === "next-link" ? (
         <Link href={link ?? ""} replace={replace} >
             <a  onClick={onClick}
+                target={target}
                 className={`group outline-none relative z-20 group disabled:opacity-30 `}
                 aria-label={`navigation ${text}`} 
                 data-analytics={`${dataAnalytics}`}
@@ -64,7 +68,7 @@ export function ButtonWrapper({children, type, onClick, replace, link, disabled,
     )
 }
 
-export default function Button5({type, text, onClick, replace, isActive, backdropBlur, link, disabled, highlight, contentId, dataAnalytics}: Props) {
+export default function Button5({type, text, onClick, replace, isActive, backdropBlur, link, disabled, highlight, contentId, dataAnalytics, target}: Props) {
     const content = useContent(contentId)
     const t = text ?? content.title
     const l = link ?? content.href
@@ -77,7 +81,7 @@ export default function Button5({type, text, onClick, replace, isActive, backdro
                 </div>
             </div>
             <div className="absolute inset-y-0 right-0 ">
-                <ButtonWrapper dataAnalytics={dataAnalytics} type={type} onClick={onClick} replace={replace} link={l} disabled={disabled} text={t} >
+                <ButtonWrapper dataAnalytics={dataAnalytics} type={type} onClick={onClick} replace={replace} link={l} disabled={disabled} text={t} target={target} >
                     <ButtonContent text={t} isActive={isActive} backdropBlur={backdropBlur} highlight={highlight} />
                 </ButtonWrapper>
             </div>

--- a/components/Button7/Button7.tsx
+++ b/components/Button7/Button7.tsx
@@ -14,7 +14,7 @@ type Props = {
     backdropBlur: boolean,
     contentId: string
     dataAnalytics: string
-    
+    target?: '_blank' | undefined
 }
 
 type ButtonWrapperProps = {
@@ -26,6 +26,7 @@ type ButtonWrapperProps = {
    disabled?: boolean 
    text?: string
    dataAnalytics: string
+   target?: '_blank' | undefined
 }
 
 
@@ -51,6 +52,7 @@ export function ButtonWrapper({...all}: ButtonWrapperProps) {
     return rest.type === "next-link" ? (
         <Link href={rest.link ?? ""} replace={rest.replace}>
             <a 
+            target={rest.target}
             className="group outline-none relative flex-none  "
             onClick={rest.onClick}
             aria-label={`navigation ${rest.text}`}
@@ -77,7 +79,7 @@ export default function Button7({...all}: Props) {
     const t = rest.text ?? content.title
     const a = content.dataAnalytics
     return (
-        <ButtonWrapper dataAnalytics={a} type={rest.type} disabled={rest.disabled} link={l} onClick={rest.onClick} replace={rest.replace} text={t} >
+        <ButtonWrapper dataAnalytics={a} type={rest.type} disabled={rest.disabled} link={l} onClick={rest.onClick} replace={rest.replace} text={t} target={rest.target} >
             <ButtonContent isActive={rest.isActive} text={t} backdropBlur={rest.backdropBlur}/>
         </ButtonWrapper>
     )

--- a/components/NavBar/NavBar.tsx
+++ b/components/NavBar/NavBar.tsx
@@ -19,6 +19,7 @@ type Link = {
     href: string,
     highlight: boolean
     dataAnalytics: string
+    target?: '_blank' | undefined
 }
 
 type ContentType = {
@@ -139,6 +140,7 @@ function NavBar({menuLinkArray, navLinkArray, languages, sections, backdropBlur,
                                         setIsOpen(false)
                                         document.body.style.overflow = "auto"
                                     }}
+                                    target={link.target}
                                     replace={true}
                                     isActive={activeHash.includes(hash)}
                                     type="next-link"
@@ -185,6 +187,7 @@ function NavBar({menuLinkArray, navLinkArray, languages, sections, backdropBlur,
                                             <Button5
                                                 key={index} 
                                                 type="next-link"
+                                                target={link.target}
                                                 onClick={() => {setIsOpen(false)}} 
                                                 replace={true}
                                                 isActive={activeHash.includes(hash)} 

--- a/content/en/general.mdx
+++ b/content/en/general.mdx
@@ -6,8 +6,9 @@ export const navLinkArray = [
     //{title: "Our vision", href: "/#ourvision", highlight: false, dataAnalytics: '"Nav Btn Click", {"props":{"section": "Our vision"}}' },
     {title: "Roadmap", href: "/#roadmap", highlight: false, dataAnalytics: '"Nav Btn Click", {"props":{"section": "Roadmap"}}' },
     // 2023/01/25: saturn hiring currently on pause. hide 'Join Us' jobs section
-    //{title: "Join us", href: "/#joinus", highlight: false, dataAnalytics: '"Nav Btn Click", {"props":{"section": "Careers"}}' },
+    // {title: "Join us", href: "/#joinus", highlight: false, dataAnalytics: '"Nav Btn Click", {"props":{"section": "Careers"}}' },
     {title: "Contact", href: "/#contact", highlight: false, dataAnalytics: '"Nav Btn Click", {"props":{"section": "Contact"}}'},
+    {title: "Docs", href: "https://docs.saturn.tech", target: "_blank", highlight: false, dataAnalytics: '"Nav Btn Click", {"props":{"section": "Docs"}}'},
     {title: "Set up your node", href: "/#setupyournode", highlight: true, dataAnalytics: '"Nav Btn Click", {"props":{"section": "Set up your node"}}' },
 ]
 
@@ -22,6 +23,7 @@ export const menuLinkArray = [
     {title: "Roadmap", href: "/#roadmap", highlight: false, dataAnalytics: '"Menu Btn Click", {"props":{"section": "Roadmap"}}' },
     {title: "Join us", href: "/#joinus", highlight: false, dataAnalytics: '"Menu Btn Click", {"props":{"section": "Join us"}}' },
     {title: "Contact", href: "/#contact", highlight: false, dataAnalytics: '"Menu Btn Click", {"props":{"section": "Contact"}}'},
+    {title: "Docs", href: "https://docs.saturn.tech", target: "_blank", highlight: false, dataAnalytics: '"Menu Btn Click", {"props":{"section": "Docs"}}'},
     {title: "Set up your node", href: "/#setupyournode", highlight: true, dataAnalytics: '"Menu Btn Click", {"props":{"section": "Set up your node"}}' },
 ]
 
@@ -32,7 +34,7 @@ export const links = [
         title: "Learn More",
         links: [
             {text: "GitHub", link: "https://github.com/filecoin-saturn/L1-node", backgroundImage: "github-logo.svg", dataAnalytics: '"Learn More GitHub Btn Click"'},
-            {text: "Notion", link: "https://pl-strflt.notion.site/Filecoin-Saturn-efc122f123f344ff8ff0de6071954dba", backgroundImage: "notion-logo.svg", dataAnalytics: '"Learn More Notion Btn Click"'},
+            {text: "Docs", link: "https://docs.saturn.tech", backgroundImage: "docs-logo.svg", dataAnalytics: '"Learn More Docs Btn Click"'},
         ]
     },
     {

--- a/public/docs-logo.svg
+++ b/public/docs-logo.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<rect width="32" height="32" fill="url(#pattern0)"/>
+<defs>
+<pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_522_2" transform="scale(0.03125)"/>
+</pattern>
+<image id="image0_522_2" width="32" height="32" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAAARklEQVR4nO3SgQ0AIAgDwe6/dN1BQAX/JviklYAXuUi/ACUhwBkTOLD3jIAIAjziA74dEEGAKz+gbwIiCPDuBNn6BAA6aAGzSWy+IbJEkwAAAABJRU5ErkJggg=="/>
+</defs>
+</svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -69,7 +69,7 @@ module.exports = {
         'inner-menu-button-hover': "url('/inner-menu-button-hover.svg')",
         'outer-menu-button-hover': "url('/outer-menu-button-hover.svg')",
         'outer-menu-button-focus': "url('/outer-menu-button-focus.svg')",
-        'notion-logo': "url('/notion-logo.svg')",
+        'docs-logo': "url('/docs-logo.svg')",
         'github-logo': "url('/github-logo.svg')",
         'slack-logo': "url('/slack-logo.svg')",
         'twitter-logo': "url('/twitter-logo.svg')",


### PR DESCRIPTION
- Removes the link to Notion in the footer
- Adds a link to docs.saturn.tech in the topbar, the mobile menu and the footer.
- When you click on the link it opens the docs page in a new tab.

Do not merge this PR until we have hosted the docs page at docs.saturn.tech