### PR TITLE
chore: fix filecoin wallet link

### DIFF
--- a/content/en/index.mdx
+++ b/content/en/index.mdx
@@ -165,7 +165,7 @@ Earn Filecoin for serving and accelerating Web3 content. The more you serve, the
 - **Dedicated Linux server with a public IPv4 address**
 - **Ports 80 and 443 free**
 - **User with sudo privileges**
-- <a target="_blank" href="https://docs.filecoin.io/reference/overview/#wallets-audited" data-analytics='"FIL Wallet Info Link Click"'>Filecoin Wallet</a>
+- <a target="_blank" href="https://docs.filecoin.io/basics/assets/wallets/#compatible-wallets" data-analytics='"FIL Wallet Info Link Click"'>Filecoin Wallet</a>
 
 {/* c:set-up-your-node.requirements.legal.title */}
 


### PR DESCRIPTION
Previous [link](https://docs.filecoin.io/reference/overview/#wallets-audited) is 404.